### PR TITLE
Implement User Practice Time Tracking and Logging

### DIFF
--- a/app/(noFooter)/play/[id]/components/PlayTranscript.tsx
+++ b/app/(noFooter)/play/[id]/components/PlayTranscript.tsx
@@ -149,6 +149,7 @@ const PlayTranscript: React.FC<Props> = ({ publicUrl, transcriptionId }) => {
             onWaveformSeek={handleWaveformSeek}
             onDurationReady={handleDurationReady}
             fileName={fileInfo?.name}
+            pageId={transcriptionId}
           />
         </div>
       </div>

--- a/app/(noFooter)/play/[id]/components/Player.tsx
+++ b/app/(noFooter)/play/[id]/components/Player.tsx
@@ -364,10 +364,7 @@ const handleBeforeUnload = useCallback(() => {
         )}
         <div ref={containerRef} className="w-full h-full" />
       </div>
-      {saving && (
-        <div className="text-xs text-blue-400 mt-2">Saving practice session...</div>
-      )}
-    </div>
+      </div>
   );
 };
 

--- a/app/(noFooter)/play/[id]/components/Player.tsx
+++ b/app/(noFooter)/play/[id]/components/Player.tsx
@@ -1,5 +1,5 @@
 // libs
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback, useEffect } from 'react';
 import WaveSurfer from 'wavesurfer.js';
 import { Pause, Play, ChevronLeft, ChevronRight } from 'lucide-react';
 import dayjs from 'dayjs';

--- a/app/(noFooter)/play/[id]/components/Player.tsx
+++ b/app/(noFooter)/play/[id]/components/Player.tsx
@@ -108,7 +108,6 @@ const finalizeSession = useCallback(
       }
       sessionStartRef.current = null;
       accumulatedTimeRef.current = 0;
-      setSessionActive(false);
     }
   },
   [savePracticeSession, pageId, fileName]

--- a/app/api/practice-session/route.ts
+++ b/app/api/practice-session/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient();
+  const body = await req.json();
+
+  // Expecting:
+  // { user_id, page_id, file_name, started_at, duration_seconds }
+  const { user_id, page_id, file_name, started_at, duration_seconds } = body;
+
+  if (!user_id || !page_id || !file_name || !started_at || !duration_seconds) {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  const { error } = await supabase.from('practice_sessions').insert([
+    {
+      user_id,
+      page_id,
+      file_name,
+      started_at,
+      duration_seconds,
+    },
+  ]);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/hooks/useLogPracticeSession.ts
+++ b/hooks/useLogPracticeSession.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+type PracticeSessionPayload = {
+  user_id: string;
+  page_id: string;
+  file_name: string;
+  started_at: string; // ISO
+  duration_seconds: number;
+};
+
+export function useLogPracticeSession() {
+  return useMutation({
+    mutationFn: async (payload: PracticeSessionPayload) => {
+      const res = await fetch('/api/practice-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return res.json();
+    },
+  });
+}

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,16 +1,14 @@
-import { createClient } from '@/utils/supabase/client';
-import { User } from '@supabase/supabase-js';
 import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/utils/supabase/client';
 
-export const useUser = () => {
-  const supabase = createClient();
-  return useQuery<User | null>({
+export function useUser() {
+  return useQuery({
     queryKey: ['user'],
     queryFn: async () => {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      return user;
+      const supabase = createClient();
+      const { data } = await supabase.auth.getUser();
+      return data?.user;
     },
+    staleTime: 5 * 60 * 1000,
   });
-};
+}

--- a/supabase/migrations/20240611_create_practice_sessions.sql
+++ b/supabase/migrations/20240611_create_practice_sessions.sql
@@ -1,0 +1,9 @@
+create table if not exists practice_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users (id) not null,
+  page_id text not null,
+  file_name text not null,
+  started_at timestamp with time zone not null,
+  duration_seconds integer not null,
+  created_at timestamp with time zone default now()
+);

--- a/supabase/migrations/20240611_create_practice_sessions.sql
+++ b/supabase/migrations/20240611_create_practice_sessions.sql
@@ -1,9 +1,0 @@
-create table if not exists practice_sessions (
-  id uuid primary key default gen_random_uuid(),
-  user_id uuid references auth.users (id) not null,
-  page_id text not null,
-  file_name text not null,
-  started_at timestamp with time zone not null,
-  duration_seconds integer not null,
-  created_at timestamp with time zone default now()
-);

--- a/supabase/migrations/20240618000000_create_practice_sessions.sql
+++ b/supabase/migrations/20240618000000_create_practice_sessions.sql
@@ -1,0 +1,33 @@
+-- Создаем таблицу practice_sessions
+create table if not exists practice_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references "User" (id) not null,
+  page_id text not null,
+  file_name text not null,
+  started_at timestamp with time zone not null,
+  duration_seconds integer not null,
+  created_at timestamp with time zone default now()
+);
+
+-- Добавляем политики безопасности
+alter table practice_sessions enable row level security;
+
+-- Политика для вставки данных
+create policy "Users can insert their own practice sessions"
+  on practice_sessions for insert
+  with check (user_id IN (
+    SELECT id FROM "User" WHERE id = auth.uid()
+  ));
+
+-- Политика для чтения данных  
+create policy "Users can view their own practice sessions"
+  on practice_sessions for select
+  using (user_id IN (
+    SELECT id FROM "User" WHERE id = auth.uid()
+  ));
+
+-- Политика для сервисной роли
+create policy "Service role can manage all practice sessions"
+  on practice_sessions for all
+  to service_role
+  using (true);


### PR DESCRIPTION
This pull request introduces a new system for tracking and logging user practice time on synchronized audio-text pages. The following changes have been made:

1. **New Practice Sessions Table**: A migration has been created to establish a `practice_sessions` table in Supabase, which will store session data including user ID, page ID, audio file name, session start time, and duration.

2. **Frontend Modifications**: The `Player` component has been updated to manage practice sessions. Key features include:
   - Starting a session when audio playback begins.
   - Accumulating playback time while audio is playing.
   - Logging the session to Supabase upon interruptions such as pause, finish, or page unload.
   - Resetting the timer for the next session after logging.

3. **Session Management**: The implementation ensures that clicking on text or scrubbing does not interrupt the session, aligning with the specified behavior.

These changes enhance the user experience by accurately tracking practice time and providing valuable data for analysis.

---

> This pull request was co-created with Cosine Genie

Original Task: [lingvo-monkeys/wbmb2do8w1o8](https://cosine.sh/blhpe62df0pg/lingvo-monkeys/task/wbmb2do8w1o8)
Author: Vladislav Sorokin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced detailed practice session tracking and logging during audio playback, including start time and duration.
  - Added a new API endpoint to record practice session data.
  - Implemented a new hook for logging practice sessions from the user interface.
  - Created a new database table to securely store practice session records.

- **Refactor**
  - Improved the user data retrieval hook for better performance and code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->