### PR TITLE
fix: enable RLS on File, Transcription and User tables

### DIFF
--- a/app/api/collection/route.ts
+++ b/app/api/collection/route.ts
@@ -2,11 +2,16 @@ import { createClient } from '@/utils/supabase/server';
 import { Tables, Columns } from '@/schema/schema';
 import { NextResponse } from 'next/server';
 
-// Email пользователя, владеющего коллекцией
+// Email пользователя, владеющего коллекцией.
+// Продублирован в public.library_owner_id() (миграция 20260902000000),
+// откуда RLS-политика на File/Transcription берёт список публичных файлов.
 const COLLECTION_OWNER_EMAIL = 'christrobs@gmail.com';
 
 export async function GET() {
-  const supabase = createClient();
+  // Сервисный ключ: роут читает чужую (владельца коллекции) строку в User,
+  // что под RLS недоступно ни anon, ни обычному авторизованному пользователю.
+  // Наружу отдаём только файлы коллекции — они и так публичные.
+  const supabase = createClient({ useServiceRole: true });
 
   try {
     // Находим пользователя в таблице User по email

--- a/app/api/files/[id]/route.ts
+++ b/app/api/files/[id]/route.ts
@@ -34,11 +34,23 @@ export async function DELETE(
     return NextResponse.json({ error: 'File ID is required' }, { status: 400 });
   }
 
-  // Fetch the file details
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Fetch the file details.
+  // Фильтр по userId обязателен: без него роут удалял объект из S3 ещё до
+  // того, как RLS отсечёт запись в БД (в том числе для файлов коллекции,
+  // которые читать может кто угодно).
   const { data: file, error: fetchError } = await supabase
     .from(Tables.FILE)
     .select('path, transcriptionId')
     .eq('id', fileId)
+    .eq(Columns.COMMON.USER_ID, user.id)
     .single();
 
   if (fetchError || !file) {

--- a/supabase/migrations/20260902000000_enable_rls_core_tables.sql
+++ b/supabase/migrations/20260902000000_enable_rls_core_tables.sql
@@ -1,0 +1,141 @@
+-- Включаем Row Level Security на таблицах File, Transcription, User.
+-- До этой миграции RLS на них не было: роль anon (её ключ лежит в публичном
+-- бандле фронтенда) имела SELECT/INSERT/UPDATE/DELETE на все строки —
+-- то есть любой мог прочитать все email'ы, все файлы и удалить чужие записи.
+-- Supabase Security Advisor: rls_disabled_in_public.
+
+-- ---------------------------------------------------------------------------
+-- Вспомогательные функции
+-- ---------------------------------------------------------------------------
+
+-- Админ определяется по email из JWT.
+-- Источник правды в коде: app/(withFooter)/admin/helpers.ts (isAdminEmail)
+-- + app/api/admin/stats/route.ts (ADMIN_EMAIL / домен @lingvomonkeys.com).
+-- При изменении списка админов правим оба места.
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    (auth.jwt() ->> 'email') IN ('sorokinvj@gmail.com', 'bichiko@gmail.com')
+    OR (auth.jwt() ->> 'email') LIKE '%@lingvomonkeys.com',
+    false
+  );
+$$;
+
+-- Владелец публичной коллекции (страница /collection и её файлы доступны всем,
+-- в том числе неавторизованным). Email продублирован в app/api/collection/route.ts.
+CREATE OR REPLACE FUNCTION public.library_owner_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM public."User" WHERE email = 'christrobs@gmail.com';
+$$;
+
+-- Функции вызываются внутри policy-выражений, поэтому EXECUTE нужен всем ролям.
+GRANT EXECUTE ON FUNCTION public.is_admin() TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.library_owner_id() TO anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- File
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public."File" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can read own or library files" ON public."File";
+CREATE POLICY "Users can read own or library files"
+  ON public."File" FOR SELECT
+  USING (
+    auth.uid() = "userId"
+    OR is_library = true
+    OR "userId" = public.library_owner_id()
+    OR public.is_admin()
+  );
+
+DROP POLICY IF EXISTS "Users can insert own files" ON public."File";
+CREATE POLICY "Users can insert own files"
+  ON public."File" FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = "userId");
+
+DROP POLICY IF EXISTS "Users can update own files" ON public."File";
+CREATE POLICY "Users can update own files"
+  ON public."File" FOR UPDATE TO authenticated
+  USING (auth.uid() = "userId")
+  WITH CHECK (auth.uid() = "userId");
+
+DROP POLICY IF EXISTS "Users can delete own files" ON public."File";
+CREATE POLICY "Users can delete own files"
+  ON public."File" FOR DELETE TO authenticated
+  USING (auth.uid() = "userId");
+
+-- ---------------------------------------------------------------------------
+-- Transcription
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public."Transcription" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can read own or library transcriptions" ON public."Transcription";
+CREATE POLICY "Users can read own or library transcriptions"
+  ON public."Transcription" FOR SELECT
+  USING (
+    auth.uid() = "userId"
+    OR "userId" = public.library_owner_id()
+    OR EXISTS (
+      SELECT 1 FROM public."File" f
+      WHERE f.id = "Transcription"."fileId" AND f.is_library = true
+    )
+    OR public.is_admin()
+  );
+
+DROP POLICY IF EXISTS "Users can insert own transcriptions" ON public."Transcription";
+CREATE POLICY "Users can insert own transcriptions"
+  ON public."Transcription" FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = "userId");
+
+DROP POLICY IF EXISTS "Users can update own transcriptions" ON public."Transcription";
+CREATE POLICY "Users can update own transcriptions"
+  ON public."Transcription" FOR UPDATE TO authenticated
+  USING (auth.uid() = "userId")
+  WITH CHECK (auth.uid() = "userId");
+
+DROP POLICY IF EXISTS "Users can delete own transcriptions" ON public."Transcription";
+CREATE POLICY "Users can delete own transcriptions"
+  ON public."Transcription" FOR DELETE TO authenticated
+  USING (auth.uid() = "userId");
+
+-- ---------------------------------------------------------------------------
+-- User
+-- ---------------------------------------------------------------------------
+-- Вставка строки при регистрации идёт триггером handle_new_user()
+-- (SECURITY DEFINER), он RLS не касается — отдельная policy не нужна.
+
+ALTER TABLE public."User" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can read own profile" ON public."User";
+CREATE POLICY "Users can read own profile"
+  ON public."User" FOR SELECT
+  USING (auth.uid() = id OR public.is_admin());
+
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER RPC: убираем доступ у ролей, которым он не нужен.
+-- Эти функции обходят RLS и принимают user_id параметром, то есть остаются
+-- дырой того же класса, если оставить их вызываемыми из браузера.
+-- ---------------------------------------------------------------------------
+
+-- Не используются приложением вообще.
+REVOKE EXECUTE ON FUNCTION public.get_user_files(uuid) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_library_count_for_user(uuid) FROM anon, authenticated;
+
+-- Вызывается только из /api/admin/user-audit сервисным ключом.
+REVOKE EXECUTE ON FUNCTION public.get_user_audit_events(uuid, integer) FROM anon, authenticated;
+
+-- Вызываются из /api/admin/stats/user-details клиентом с сессией пользователя,
+-- поэтому authenticated оставляем; anon — нет.
+REVOKE EXECUTE ON FUNCTION public.count_page_views() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.count_player_interactions() FROM anon;


### PR DESCRIPTION
## Что и зачем

Supabase Security Advisor прислал `rls_disabled_in_public` по проекту Lingvo Monkeys (`velkhnpgivmayfalrnlb`).

Факты, проверенные на проде:
- RLS был выключен на `File`, `Transcription`, `User` (на аналитических таблицах он есть);
- роли `anon` и `authenticated` имеют гранты `SELECT/INSERT/UPDATE/DELETE` на эти таблицы, а anon-ключ лежит в публичном бандле фронтенда → через PostgREST можно было прочитать 121 email, все 104 файла с транскрипциями и удалить любые записи;
- `SECURITY DEFINER` функции `get_user_files(uuid)`, `get_user_audit_events(uuid, int)`, `get_library_count_for_user(uuid)` были доступны `anon` и принимают `user_id` параметром — обход RLS того же класса;
- `DELETE /api/files/[id]` вообще не проверял пользователя: удалял объект из S3 по `path`, а потом запись из БД.

## Изменения

**Миграция `20260902000000_enable_rls_core_tables.sql`**
- `is_admin()` — админ по email из JWT (список зеркалит `admin/helpers.ts` + домен `@lingvomonkeys.com`);
- `library_owner_id()` — аккаунт публичной коллекции (`christrobs@gmail.com`), чтобы /collection и /play оставались доступны неавторизованным;
- политики: чтение своих строк + файлов коллекции + админ; запись/удаление — только свои строки (`authenticated`);
- `REVOKE EXECUTE` у `anon` на перечисленные RPC (у `count_page_views` / `count_player_interactions` оставлен `authenticated` — их зовёт админский роут с пользовательской сессией).

**Код**
- `/api/collection` → сервисный ключ (роут читает чужую строку в `User`);
- `DELETE /api/files/[id]` → проверка сессии и `userId` до обращения к S3.

## Проверка

Миграция прогнана на прод-БД в транзакции с `ROLLBACK`:

| роль | File | User | Transcription |
|---|---|---|---|
| anon | 19 (коллекция) | 0 | 19 |
| обычный юзер (6 своих файлов) | 25 | 1 (своя) | 25 |
| админ | 104 | 121 | 103 |
| service_role | 104 | 121 | — |

Попытка удалить чужой файл из-под обычного юзера — 0 строк. `next build` проходит.

Порядок: сначала мержим и деплоим этот PR, только потом применяем миграцию к проду — иначе старый код `/api/collection` упадёт под RLS.

## Что осталось за рамками (сообщено владельцу)
- админские роуты статистики читают аналитические таблицы пользовательской сессией, а там RLS «только свои строки» — часть цифр в дашборде занижена уже сейчас;
- `/api/admin/stats/user-details` зовёт `get_user_listening_stats`, которая удалена миграцией `20250525000003`;
- локальная папка `supabase/migrations` отстаёт от прода (в БД есть миграции до `20250530`, в репозитории — до `20240617`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNox8yQspZmik7EzaKv6Tg