### PR TITLE
fix: revoke PUBLIC execute on definer RPCs, 404 instead of 500 on /play

### DIFF
--- a/app/(noFooter)/play/[id]/page.tsx
+++ b/app/(noFooter)/play/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/utils/supabase/server';
+import { notFound } from 'next/navigation';
 import { Tables, Columns } from '@/schema/schema';
 import {
   dehydrate,
@@ -17,12 +18,10 @@ export default async function PlayPage({ params }: { params: { id: string } }) {
     .eq('id', params.id)
     .single();
 
-  if (fileError) {
-    throw new Error(`Error fetching file: ${fileError.message}`);
-  }
-
-  if (!file) {
-    throw new Error('File not found');
+  // Под RLS чужой приватный файл просто не возвращается (PGRST116 у .single()),
+  // поэтому «нет доступа» и «нет файла» — одна и та же ветка: 404, а не 500.
+  if (fileError || !file) {
+    notFound();
   }
 
   const queryClient = new QueryClient();

--- a/supabase/migrations/20260902000001_revoke_public_execute_on_rpc.sql
+++ b/supabase/migrations/20260902000001_revoke_public_execute_on_rpc.sql
@@ -1,0 +1,22 @@
+-- Дополнение к 20260902000000: REVOKE у anon/authenticated не сработал,
+-- потому что EXECUTE на этих функциях выдан ещё и роли PUBLIC
+-- (в ACL это запись "=X/postgres"), а она наследуется всеми.
+-- Проверено на проде: после первой миграции анонимный ключ всё ещё получал
+-- ответ от get_user_files и get_user_audit_events по чужому user_id.
+
+REVOKE EXECUTE ON FUNCTION public.get_user_files(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_library_count_for_user(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_user_audit_events(uuid, integer)
+  FROM PUBLIC, anon, authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.count_page_views() FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.count_player_interactions() FROM PUBLIC, anon;
+
+-- Вызываются из /api/admin/stats/user-details клиентом с сессией пользователя.
+GRANT EXECUTE ON FUNCTION public.count_page_views() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.count_player_interactions() TO authenticated, service_role;
+
+-- Вызывается из /api/admin/user-audit сервисным ключом.
+GRANT EXECUTE ON FUNCTION public.get_user_audit_events(uuid, integer) TO service_role;


### PR DESCRIPTION
Догоняющий PR к #19, обе находки — с проверки прода после включения RLS.

**1. `REVOKE ... FROM anon, authenticated` не закрыл доступ к SECURITY DEFINER функциям.**
EXECUTE на них выдан ещё и роли `PUBLIC` (в ACL это `=X/postgres`), поэтому анонимный ключ продолжал получать данные:

```
$ curl .../rest/v1/rpc/get_user_audit_events -d '{"user_id":"<чужой uuid>"}'  # anon key
{"upload_events": [{...}]}   # до фикса
{"code":"42501","message":"permission denied for function get_user_audit_events"}  # после
```

Миграция `20260902000001` снимает грант с `PUBLIC` и возвращает явные гранты: `count_page_views` / `count_player_interactions` → `authenticated` + `service_role` (их зовёт админский роут пользовательской сессией), `get_user_audit_events` → `service_role`, `get_user_files` / `get_library_count_for_user` → только `service_role` (приложение их не вызывает). Применена к проду.

**2. `/play/[id]` на недоступный файл отдавал 500.**
Страница кидала `throw new Error` на любой ошибке запроса. Под RLS «чужой приватный файл» — штатная ситуация, а не сбой, поэтому анонимный переход по такой ссылке показывал белый экран `Application error`. Теперь `notFound()` → обычная 404.

**Проверка на проде (анонимно, в браузере):**
- `/collection` — 19 файлов, таблица рендерится;
- `/play/<файл коллекции>` — заголовок, транскрипт, плеер на месте;
- `/play/<чужой приватный файл>` — до фикса `Application error`, после мержа должно быть 404 (перепроверю после деплоя);
- `GET /rest/v1/User` с anon-ключом → `[]`, `File` → 19 из 104, `Transcription` → 19 из 103;
- `DELETE /rest/v1/File?id=eq...` с anon-ключом → 0 удалённых строк (104 файла и 121 пользователь на месте).

`next build` проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNox8yQspZmik7EzaKv6Tg