### PR TITLE
fix: webhook транскрипции пишет сервисным ключом, закрыт /api/admin/user-audit

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -2,6 +2,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { Tables, Columns } from '@/schema/schema';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { isAdminEmail } from '@/app/(withFooter)/admin/helpers';
 
 // Mark this route as dynamic to prevent static generation errors
 export const dynamic = 'force-dynamic';
@@ -17,12 +18,14 @@ async function isAdmin(userId: string) {
     .eq('id', userId)
     .single();
 
-  // Check if the user is an admin
-  // You may want to replace this with a proper admin role check
-  return (
-    userData?.email &&
-    (userData.email === process.env.ADMIN_EMAIL ||
-      userData.email.endsWith('@lingvomonkeys.com'))
+  // Список админов — тот же, что у страницы /admin (isAdminEmail), иначе
+  // дашборд открывается, а этот роут отвечает 403. ADMIN_EMAIL и домен
+  // оставлены как дополнительное разрешение.
+  return Boolean(
+    isAdminEmail(userData?.email) ||
+      (userData?.email &&
+        (userData.email === process.env.ADMIN_EMAIL ||
+          userData.email.endsWith('@lingvomonkeys.com')))
   );
 }
 

--- a/app/api/admin/user-audit/route.ts
+++ b/app/api/admin/user-audit/route.ts
@@ -2,12 +2,40 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { Tables, Columns } from '@/schema/schema';
 import { UserAuditData } from '@/app/(withFooter)/admin/[email]/components/types';
+import { isAdminEmail } from '@/app/(withFooter)/admin/helpers';
 
 // Mark this route as dynamic to prevent static generation errors
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
+    // Роут ходит сервисным ключом и отдаёт всю историю событий любого
+    // пользователя по email, поэтому доступ к нему обязан быть только у админа.
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { data: null, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const { data: currentUser } = await supabase
+      .from(Tables.USER)
+      .select('email')
+      .eq('id', user.id)
+      .single();
+
+    if (!isAdminEmail(currentUser?.email)) {
+      return NextResponse.json(
+        { data: null, error: 'Admin access required' },
+        { status: 403 }
+      );
+    }
+
     const adminClient = createClient({ useServiceRole: true });
     // Получение email пользователя из параметров запроса
     const searchParams = new URL(request.url).searchParams;

--- a/app/api/transcription-callback/route.ts
+++ b/app/api/transcription-callback/route.ts
@@ -14,7 +14,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = createClient();
+    // Вебхук приходит от Deepgram без сессии пользователя, поэтому вся запись
+    // идёт сервисным ключом: под RLS анонимный клиент обновил бы 0 строк и
+    // файл навсегда остался бы в статусе "transcribing".
     const adminClient = createClient({ useServiceRole: true });
 
     const body = await request.json();
@@ -26,7 +28,7 @@ export async function POST(request: NextRequest) {
     const transcript = body.results.channels[0].alternatives[0].transcript;
 
     // Update the Transcription record with the results
-    const { data: transcriptionData, error } = await supabase
+    const { data: transcriptionData, error } = await adminClient
       .from(Tables.TRANSCRIPTION)
       .update({
         content: transcript,
@@ -48,7 +50,7 @@ export async function POST(request: NextRequest) {
     const updatedTranscription = transcriptionData[0]; // It's an array, so we take the first item
 
     // Update the File record with the new transcriptionId and status
-    const { data: fileData, error: updateFileError } = await supabase
+    const { data: fileData, error: updateFileError } = await adminClient
       .from(Tables.FILE)
       .update({
         status: 'transcribed',

--- a/supabase/migrations/20260902000002_admin_read_analytics.sql
+++ b/supabase/migrations/20260902000002_admin_read_analytics.sql
@@ -1,0 +1,26 @@
+-- Админский дашборд (/api/admin/stats/*) ходит в аналитические таблицы
+-- клиентом с сессией пользователя, а там RLS "только свои строки".
+-- Из-за этого часть цифр в дашборде занижена — например settingsChanges
+-- в /api/admin/stats/user-details считался только по строкам самого админа.
+-- Добавляем админу право на чтение. Политики аддитивны: обычный пользователь
+-- по-прежнему видит только свои события.
+
+DROP POLICY IF EXISTS "Admins can read all upload events" ON public."FileUploadEvent";
+CREATE POLICY "Admins can read all upload events"
+  ON public."FileUploadEvent" FOR SELECT USING (public.is_admin());
+
+DROP POLICY IF EXISTS "Admins can read all listening events" ON public."FileListeningEvent";
+CREATE POLICY "Admins can read all listening events"
+  ON public."FileListeningEvent" FOR SELECT USING (public.is_admin());
+
+DROP POLICY IF EXISTS "Admins can read all page views" ON public."PageViewEvent";
+CREATE POLICY "Admins can read all page views"
+  ON public."PageViewEvent" FOR SELECT USING (public.is_admin());
+
+DROP POLICY IF EXISTS "Admins can read all player interactions" ON public."PlayerInteractionEvent";
+CREATE POLICY "Admins can read all player interactions"
+  ON public."PlayerInteractionEvent" FOR SELECT USING (public.is_admin());
+
+DROP POLICY IF EXISTS "Admins can read all settings changes" ON public."SettingsChangeEvent";
+CREATE POLICY "Admins can read all settings changes"
+  ON public."SettingsChangeEvent" FOR SELECT USING (public.is_admin());


### PR DESCRIPTION
Третий PR по итогам включения RLS (#19, #20). Здесь одна регрессия от моих же правок и две дыры, которые RLS не закрывал.

### 1. Регрессия: загрузка файлов ломалась после включения RLS

`/api/transcription-callback` обновлял `Transcription` и `File` **анонимным** клиентом. Вебхук приходит от Deepgram без сессии, поэтому под RLS это 0 строк → роут падает в 500, а файл навсегда остаётся в статусе `transcribing`.

Проверено на прод-БД:
```
SET ROLE anon;
UPDATE "Transcription" ... → 0 строк
UPDATE "File" ...          → 0 строк
```
Переведено на сервисный ключ (`FileUploadEvent` в этом же роуте им уже писался).

### 2. `/api/admin/user-audit` был открыт всему интернету

Роут ходит сервисным ключом и не проверял пользователя вообще. До фикса, без всякой авторизации:
```
GET https://lingvomonkeys.com/api/admin/user-audit?email=<чужой email>  → 200
{upload_events: 27, player_events: 100, settings_events: 57, page_view_events: 100, listening_events: 100}
```
Добавлены проверка сессии (401) и `isAdminEmail` (403).

### 3. Разъехавшиеся проверки админа

`/api/admin/stats` проверял `ADMIN_EMAIL` из env и домен `@lingvomonkeys.com`, а страница `/admin` — хардкод-список `isAdminEmail`. Если `ADMIN_EMAIL` не задан в Vercel, дашборд открывается, а роут отвечает 403. Списки объединены.

### 4. Миграция `20260902000002` — админ снова видит аналитику

На аналитических таблицах RLS «только свои строки» стоял и до моих правок, из-за чего дашборд занижал цифры (например `settingsChanges` считался только по строкам самого админа). Добавлены `SELECT`-политики для `is_admin()`.

Проверено на проде в транзакции с откатом:

| | PageViewEvent | SettingsChangeEvent | PlayerInteractionEvent |
|---|---|---|---|
| админ | 1788 | 150 | 4495 |
| обычный юзер | 0 | 0 | — |
| всего в таблице | 1788 | 150 | 4495 |

Миграция уже применена к проду. `next build` проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNox8yQspZmik7EzaKv6Tg